### PR TITLE
Add time dependent boundary conditions

### DIFF
--- a/flowforge/input/BoundaryConditions.py
+++ b/flowforge/input/BoundaryConditions.py
@@ -222,24 +222,25 @@ class GeneralBC(abc.ABC):
         return self._surface_name
 
     def convertUnits(self, uc: UnitConverter) -> None:
-        conversion_factor = self._get_variable_conversion(uc)
-        self.boundary_value = self.boundary_value * conversion_factor
+        scale_factor, shift_factor = self._get_variable_conversion(uc)
+        self.boundary_value.performUnitConversion(scale_factor, shift_factor)
 
     def _get_variable_conversion(self, uc: UnitConverter):
+        scale_factor, shift_factor = 1, 0
         if self.variable_name == "mass_flow_rate":
-            conversion_factor = uc.massFlowRateConversion
+            scale_factor = uc.massFlowRateConversion
         elif self.variable_name == "pressure":
-            conversion_factor = uc.pressureConversion
+            scale_factor = uc.pressureConversion
         elif self.variable_name == "temperature":
-            conversion_factor = uc.temperatureConversion(self.boundary_value) / self.boundary_value
+            scale_factor, shift_factor = uc.temperatureConversionFactors
         elif self.variable_name == "enthalpy":
-            conversion_factor = uc.enthalpyConversion
+            scale_factor = uc.enthalpyConversion
         else:
             raise Exception('ERROR: non-valid variable name: '+self.variable_name+'.')
-        return conversion_factor
+        return scale_factor, shift_factor
 
-    def createExpression(self, function, coupled_variables):
-        return EquationParser(function, *coupled_variables.values())
+    def createExpression(self, function):
+        return EquationParser(function)
 
 class DirichletBC(GeneralBC):
     """

--- a/flowforge/input/BoundaryConditions.py
+++ b/flowforge/input/BoundaryConditions.py
@@ -190,7 +190,7 @@ class GeneralBC(abc.ABC):
         - _variable_name : str
         - _value: float
     """
-    def __init__(self, surface: str, variable: str, value=None, function=None, **coupledVariables):
+    def __init__(self, surface: str, variable: str, value=None, function=None):
         self._surface_name = surface
         self._variable_name = variable
         self._value = value
@@ -199,7 +199,6 @@ class GeneralBC(abc.ABC):
         self.bc_type = "None"
 
         if function is not None:
-            self._coupled_variables = {input_name: coupled_variable for input_name, coupled_variable in coupledVariables.items()}
             self._expression = self.createExpression(function, self._coupled_variables)
 
     @property

--- a/flowforge/input/BoundaryConditions.py
+++ b/flowforge/input/BoundaryConditions.py
@@ -1,5 +1,6 @@
 import abc
 from flowforge.input.UnitConverter import UnitConverter
+from flowforge.parsers.EquationParser import EquationParser
 
 class MassMomentumBC:
     """Class for mass and momentum BC
@@ -189,12 +190,17 @@ class GeneralBC(abc.ABC):
         - _variable_name : str
         - _value: float
     """
-    def __init__(self, surface: str, variable: str, value: float):
+    def __init__(self, surface: str, variable: str, value=None, function=None, **coupledVariables):
         self._surface_name = surface
         self._variable_name = variable
         self._value = value
+        self._function = function
 
         self.bc_type = "None"
+
+        if function is not None:
+            self._coupled_variables = {input_name: coupled_variable for input_name, coupled_variable in coupledVariables.items()}
+            self._expression = self.createExpression(function, self._coupled_variables)
 
     @property
     def boundary_type(self):
@@ -207,6 +213,10 @@ class GeneralBC(abc.ABC):
     @property
     def boundary_value(self):
         return self._value
+
+    @property
+    def boundary_expression(self):
+        return self._expression
 
     @boundary_value.setter
     def boundary_value(self, value):
@@ -236,6 +246,9 @@ class GeneralBC(abc.ABC):
         else:
             raise Exception('ERROR: non-valid variable name: '+self.variable_name+'.')
         return conversion_factor
+
+    def createExpression(self, function, coupled_variables):
+        return EquationParser(function, *coupled_variables.values())
 
 class DirichletBC(GeneralBC):
     """

--- a/flowforge/input/BoundaryConditions.py
+++ b/flowforge/input/BoundaryConditions.py
@@ -190,16 +190,12 @@ class GeneralBC(abc.ABC):
         - _variable_name : str
         - _value: float
     """
-    def __init__(self, surface: str, variable: str, value=None, function=None):
+    def __init__(self, surface: str, variable: str, value):
         self._surface_name = surface
         self._variable_name = variable
-        self._value = value
-        self._function = function
+        self._value = self.createExpression(str(value))
 
         self.bc_type = "None"
-
-        if function is not None:
-            self._expression = self.createExpression(function, self._coupled_variables)
 
     @property
     def boundary_type(self):
@@ -212,10 +208,6 @@ class GeneralBC(abc.ABC):
     @property
     def boundary_value(self):
         return self._value
-
-    @property
-    def boundary_expression(self):
-        return self._expression
 
     @boundary_value.setter
     def boundary_value(self, value):

--- a/flowforge/input/BoundaryConditions.py
+++ b/flowforge/input/BoundaryConditions.py
@@ -193,7 +193,7 @@ class GeneralBC(abc.ABC):
     def __init__(self, surface: str, variable: str, value):
         self._surface_name = surface
         self._variable_name = variable
-        self._value = self.createExpression(str(value))
+        self._value = EquationParser(str(value))
 
         self.bc_type = "None"
 
@@ -238,9 +238,6 @@ class GeneralBC(abc.ABC):
         else:
             raise Exception('ERROR: non-valid variable name: '+self.variable_name+'.')
         return scale_factor, shift_factor
-
-    def createExpression(self, function):
-        return EquationParser(function)
 
 class DirichletBC(GeneralBC):
     """

--- a/flowforge/input/UnitConverter.py
+++ b/flowforge/input/UnitConverter.py
@@ -153,21 +153,21 @@ class UnitConverter:
                 raise Exception("Unknown enthalpy input type: " + unitdict["enthalpy"])
 
         self._tempconv = lambda T: T
-        scale_temp_by = 1; shift_temp_by = 0
+        scale_temp_by, shift_temp_by = 1, 0
         if "temperature" in unitdict:
             # converting to K
             if unitdict["temperature"] == "K":
                 self._tempconv = lambda T: T
-                scale_temp_by = 1; shift_temp_by = 0
+                scale_temp_by, shift_temp_by = 1, 0
             elif unitdict["temperature"] == "C":
                 self._tempconv = lambda T: T + 273.15
-                scale_temp_by = 1; shift_temp_by = 273.15
+                scale_temp_by, shift_temp_by = 1, 273.15
             elif unitdict["temperature"] == "F":
                 self._tempconv = lambda T: (T - 32) * 5 / 9 + 273.15
-                scale_temp_by = 5.0/9.0; shift_temp_by = 273.15 - (32.0*5.0/9.0)
+                scale_temp_by, shift_temp_by = 5.0/9.0, 273.15 - (32.0*5.0/9.0)
             elif unitdict["temperature"] == "R":
                 self._tempconv = lambda T: T * 5 / 9
-                scale_temp_by = 5.0/9.0; shift_temp_by = 0
+                scale_temp_by, shift_temp_by = 5.0/9.0, 0
             else:
                 raise Exception("Unknown temperature input type: " + unitdict["temperature"])
         self._tempconvfactors = [scale_temp_by, shift_temp_by]

--- a/flowforge/input/UnitConverter.py
+++ b/flowforge/input/UnitConverter.py
@@ -153,18 +153,24 @@ class UnitConverter:
                 raise Exception("Unknown enthalpy input type: " + unitdict["enthalpy"])
 
         self._tempconv = lambda T: T
+        scale_temp_by = 1; shift_temp_by = 0
         if "temperature" in unitdict:
             # converting to K
             if unitdict["temperature"] == "K":
                 self._tempconv = lambda T: T
+                scale_temp_by = 1; shift_temp_by = 0
             elif unitdict["temperature"] == "C":
                 self._tempconv = lambda T: T + 273.15
+                scale_temp_by = 1; shift_temp_by = 273.15
             elif unitdict["temperature"] == "F":
                 self._tempconv = lambda T: (T - 32) * 5 / 9 + 273.15
+                scale_temp_by = 5.0/9.0; shift_temp_by = 273.15 - (32.0*5.0/9.0)
             elif unitdict["temperature"] == "R":
                 self._tempconv = lambda T: T * 5 / 9
+                scale_temp_by = 5.0/9.0; shift_temp_by = 0
             else:
                 raise Exception("Unknown temperature input type: " + unitdict["temperature"])
+        self._tempconvfactors = [scale_temp_by, shift_temp_by]
 
     @property
     def lengthConversion(self) -> float:
@@ -216,3 +222,7 @@ class UnitConverter:
             The equivalent temperature in :math:`K`
         """
         return self._tempconv(T)
+
+    @property
+    def temperatureConversionFactors(self) -> list:
+        return self._tempconvfactors

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -1,5 +1,5 @@
-import sympy
 import re
+import sympy
 
 class EquationParser:
     """

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -1,0 +1,55 @@
+import abc
+import sympy
+import numpy as np
+
+class EquationParser:
+    def __init__(self, equation: str, *coupled_variables):
+        self._input_equation = equation
+        self._expression = sympy.sympify(equation)
+        self._t = sympy.symbols('t')
+        self._x = sympy.symbols('x')
+        self._y = sympy.symbols('y')
+        self._z = sympy.symbols('z')
+        self._coupled_variables = {i: sympy.symbols(i) for i in coupled_variables}
+
+    @property
+    def inputEquation(self):
+        return self._input_equation
+
+    @property
+    def expression(self):
+        return self._expression
+
+    @property
+    def time(self):
+        return self._t
+
+    @property
+    def xCoord(self):
+        return self._x
+
+    @property
+    def yCoord(self):
+        return self._y
+
+    @property
+    def zCoord(self):
+        return self._z
+
+    @property
+    def coupledVariables(self):
+        return self._variables
+
+    def evaluate(self, x=None, y=None, z=None, t=None, **kwargs):
+        expression = self.expression
+        if x is not None:
+            expression.subs(self.xCoord, x)
+        if y is not None:
+            expression.subs(self.yCoord, y)
+        if z is not None:
+            expression.subs(self.zCoord, z)
+        if t is not None:
+            expression.subs(self.time, t)
+
+        for variable_name, value in kwargs.items():
+            expression.subs(self.coupledVariables[variable_name], value)

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -50,9 +50,10 @@ class EquationParser:
         self._expression = sympy.sympify(equation)
 
         potential_variable = ['x', 'y', 'z', 't'] + list(coupled_variables)
-        variable_names = self._extract_variable_name(equation)
+        variable_names_extracted_from_equation = [var for var in re.findall(r'[\w]+', equation)
+                                                  if any(char.isalpha() for char in var)]
         self._variables = {var: sympy.symbols(var) for var in potential_variable
-                           if var in variable_names}
+                           if var in variable_names_extracted_from_equation}
 
     @property
     def inputEquation(self):
@@ -73,19 +74,6 @@ class EquationParser:
     @property
     def variables(self):
         return self._variables
-
-    def _extract_variable_name(self, equation):
-        """
-        variables = ''.join(character if character.isalpha()
-                            else ' ' for character in equation).split()
-        """
-        variables = [var for var in re.findall(r'[\w]+', equation) if any(char.isalpha() for char in var)]
-        return variables
-
-    def _generate_expression_input(self, all_input: dict):
-        expression_input = {self._variables[var]: all_input[var]
-                            for var in [*self._variables.keys()]}
-        return expression_input
 
     def performUnitConversion(self, scale_factor=1, shift_factor=0,):
         scaled_equation = "(" + str(scale_factor) + " * (" + self.inputEquation + ")) + " + str(shift_factor)

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -6,7 +6,7 @@ class EquationParser:
         self._expression = sympy.sympify(equation)
 
         potential_variable = ['x', 'y', 'z', 't'] + [i for i in coupled_variables]
-        variable_names = self.extract_variable_name(equation)
+        variable_names = self._extract_variable_name(equation)
         self._variables = {var: sympy.symbols(var) for var in potential_variable
                            if var in variable_names}
 
@@ -18,7 +18,7 @@ class EquationParser:
     def expression(self):
         return self._expression
 
-    def extract_variable_name(self, equation):
+    def _extract_variable_name(self, equation):
         variables = ''.join(character if character.isalpha()
                             else ' ' for character in equation).split()
         return variables

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -1,4 +1,5 @@
 import sympy
+import re
 
 class EquationParser:
     """
@@ -74,8 +75,11 @@ class EquationParser:
         return self._variables
 
     def _extract_variable_name(self, equation):
+        """
         variables = ''.join(character if character.isalpha()
                             else ' ' for character in equation).split()
+        """
+        variables = [var for var in re.findall(r'[\w]+', equation) if any(char.isalpha() for char in var)]
         return variables
 
     def _generate_expression_input(self, all_input: dict):

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -1,11 +1,54 @@
 import sympy
 
 class EquationParser:
+    """
+    Class for handling the parsing of input equation.
+
+    This object takes in a string-equation and deciphers the variables
+    used and generates an expression using sympy.
+
+    The class automatically creates 4 independent variables for use:
+      1. 'x': x-spatial coordinate
+      2. 'y': y-spatial coordinate
+      3. 'z': z-spatial coordinate
+      4. 't': time
+    The class also allows for coupled variables to declared. They should
+    be input as a list of variable names (i.e. ['temperature', 'pressure'])
+
+    The 'generate' method takes in keyword arguments for the variables,
+    disregarding variables not used in the original expression (those of
+    which the equation is not dependent on).
+
+    Parameters
+    ----------
+      -> equation : string
+      -> coupled_variables : *args (list)
+
+    Attributes
+    ----------
+      -> inputEquation : string
+      -> expression : sympify-object
+      -> variables : dict{string : sympy.symbol}
+
+    Methods
+    -------
+      -> _extract_variable_name : (private) extracts all variables from the
+            input equation
+      -> _generate_expression_input : (private) extracts valid variables from
+            the input arguments in 'evaluate' and ignores unused variables.
+      -> performUnitConversion : adds a scaling factor and shifting factor to
+            the expression in the form
+                        'new_eqn = (scaler * original+eqn) + shifter'.
+            The new equation is them turned into an expression that may be
+            properly evaluated.
+      -> evaluate : takes in variable values and outputs the solution to the
+            evaluated function.
+    """
     def __init__(self, equation: str, *coupled_variables):
         self._input_equation = equation
         self._expression = sympy.sympify(equation)
 
-        potential_variable = ['x', 'y', 'z', 't'] + [i for i in coupled_variables]
+        potential_variable = ['x', 'y', 'z', 't'] + list(coupled_variables)
         variable_names = self._extract_variable_name(equation)
         self._variables = {var: sympy.symbols(var) for var in potential_variable
                            if var in variable_names}
@@ -26,6 +69,10 @@ class EquationParser:
     def expression(self, value):
         self._expression = value
 
+    @property
+    def variables(self):
+        return self._variables
+
     def _extract_variable_name(self, equation):
         variables = ''.join(character if character.isalpha()
                             else ' ' for character in equation).split()
@@ -43,8 +90,7 @@ class EquationParser:
         self.expression = scaled_expression
 
     def evaluate(self, x=None, y=None, z=None, t=None, **coupled_variables):
-        full_input = {'x': x, 'y': y, 'z': z, 't': t} \
-            | {variable_name: value for variable_name, value in coupled_variables.items()}
+        full_input = {'x': x, 'y': y, 'z': z, 't': t} + dict(coupled_variables)
         expression_input = self._generate_expression_input(full_input)
         expression = self._expression.subs(expression_input)
 

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -10,14 +10,6 @@ class EquationParser:
         self._variables = {var: sympy.symbols(var) for var in potential_variable
                            if var in variable_names}
 
-    @property
-    def inputEquation(self):
-        return self._input_equation
-
-    @property
-    def expression(self):
-        return self._expression
-
     def _extract_variable_name(self, equation):
         variables = ''.join(character if character.isalpha()
                             else ' ' for character in equation).split()
@@ -32,6 +24,6 @@ class EquationParser:
         full_input = {'x': x, 'y': y, 'z': z, 't': t} \
             | {variable_name: value for variable_name, value in coupled_variables.items()}
         expression_input = self._generate_expression_input(full_input)
-        expression = self.expression.subs(expression_input)
+        expression = self._expression.subs(expression_input)
 
         return float(expression)

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -10,6 +10,22 @@ class EquationParser:
         self._variables = {var: sympy.symbols(var) for var in potential_variable
                            if var in variable_names}
 
+    @property
+    def inputEquation(self):
+        return self._input_equation
+
+    @inputEquation.setter
+    def inputEquation(self, value):
+        self._input_equation = value
+
+    @property
+    def expression(self):
+        return self._expression
+
+    @expression.setter
+    def expression(self, value):
+        self._expression = value
+
     def _extract_variable_name(self, equation):
         variables = ''.join(character if character.isalpha()
                             else ' ' for character in equation).split()
@@ -19,6 +35,12 @@ class EquationParser:
         expression_input = {self._variables[var]: all_input[var]
                             for var in [*self._variables.keys()]}
         return expression_input
+
+    def performUnitConversion(self, scale_factor=1, shift_factor=0,):
+        scaled_equation = "(" + str(scale_factor) + " * (" + self.inputEquation + ")) + " + str(shift_factor)
+        scaled_expression = sympy.sympify(scaled_equation)
+        self.inputEquation = scaled_equation
+        self.expression = scaled_expression
 
     def evaluate(self, x=None, y=None, z=None, t=None, **coupled_variables):
         full_input = {'x': x, 'y': y, 'z': z, 't': t} \

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -91,7 +91,7 @@ class EquationParser:
 
     def evaluate(self, x=None, y=None, z=None, t=None, **coupled_variables):
         full_input = {'x': x, 'y': y, 'z': z, 't': t} | dict(coupled_variables)
-        expression_input = self._generate_expression_input(full_input)
-        expression = self._expression.subs(expression_input)
+        reduced_input = {self._variables[var]: full_input[var] for var in [*self._variables.keys()]}
+        expression = self._expression.subs(reduced_input)
 
         return float(expression)

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -90,7 +90,7 @@ class EquationParser:
         self.expression = scaled_expression
 
     def evaluate(self, x=None, y=None, z=None, t=None, **coupled_variables):
-        full_input = {'x': x, 'y': y, 'z': z, 't': t} + dict(coupled_variables)
+        full_input = {'x': x, 'y': y, 'z': z, 't': t} | dict(coupled_variables)
         expression_input = self._generate_expression_input(full_input)
         expression = self._expression.subs(expression_input)
 

--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -38,18 +38,20 @@ class EquationParser:
 
     @property
     def coupledVariables(self):
-        return self._variables
+        return self._coupled_variables
 
     def evaluate(self, x=None, y=None, z=None, t=None, **kwargs):
         expression = self.expression
         if x is not None:
-            expression.subs(self.xCoord, x)
+            expression = expression.subs(self.xCoord, x)
         if y is not None:
-            expression.subs(self.yCoord, y)
+            expression = expression.subs(self.yCoord, y)
         if z is not None:
-            expression.subs(self.zCoord, z)
+            expression = expression.subs(self.zCoord, z)
         if t is not None:
-            expression.subs(self.time, t)
+            expression = expression.subs(self.time, t)
 
         for variable_name, value in kwargs.items():
-            expression.subs(self.coupledVariables[variable_name], value)
+            expression = expression.subs(self.coupledVariables[variable_name], value)
+
+        return float(expression)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "h5py",
     "pyevtk",
     "vtk",
-    sympy,
+    "sympy",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "h5py",
     "pyevtk",
     "vtk",
+    sympy,
 ]
 
 [project.optional-dependencies]

--- a/tests/parsers/test_EquationParser.py
+++ b/tests/parsers/test_EquationParser.py
@@ -1,5 +1,19 @@
 from flowforge.parsers.EquationParser import EquationParser
 
+def test_constant_equation():
+    test_name = "test_constant_equation"
+    equation = '11.2'
+    expression = EquationParser(equation)
+    variables = ['x']
+
+    test_inputs = [[1],
+                   [5],
+                   [1.2]]
+    expected_results = [11.2, 11.2, 11.2]
+
+    test_all_values(variables, expression, test_name, equation,
+                    test_inputs, expected_results)
+
 def test_spatial_equation():
     test_name = "test_spatial_equation"
     equation = '10.1*x + (15.6 / y) - z**2'
@@ -83,6 +97,7 @@ def withinRoundingPrecision(true, predicted):
         return False
 
 if __name__ == "__main__":
+    test_constant_equation()
     test_spatial_equation()
     test_time_dependent_equation()
     test_spatial_and_time_equation()

--- a/tests/parsers/test_EquationParser.py
+++ b/tests/parsers/test_EquationParser.py
@@ -70,6 +70,24 @@ def test_coupled_variables():
     test_all_values(variables, expression, test_name, equation,
                     test_inputs, expected_results)
 
+def test_unit_conversion():
+    test_name = "test_unit_conversion"
+    equation = '10.1 + 3.2*x'
+    expression = EquationParser(equation)
+    variables = ['x']
+
+    scale_factor = 1.8
+    shift_factor = 22
+    expression.performUnitConversion(scale_factor, shift_factor)
+
+    test_inputs = [[1],
+                   [5],
+                   [4.6]]
+    expected_results = [45.94, 68.98, 66.676]
+
+    test_all_values(variables, expression, test_name, equation,
+                    test_inputs, expected_results)
+
 def test_all_values(variables, expression, test_name, original_equation, test_inputs, expected_values):
     number_of_variables = len(variables)
     number_of_tests = len(test_inputs)
@@ -102,3 +120,4 @@ if __name__ == "__main__":
     test_time_dependent_equation()
     test_spatial_and_time_equation()
     test_coupled_variables()
+    test_unit_conversion()

--- a/tests/parsers/test_EquationParser.py
+++ b/tests/parsers/test_EquationParser.py
@@ -53,7 +53,7 @@ def test_spatial_and_time_equation():
     test_inputs = [(1, 1, 1, 1),
                    (5, 5, 5, 5),
                    (1.2, 2.0, 0.2, 0.8)]
-    expected_results = [24.7, 5.724, 24.85]
+    expected_results = [24.7, 5.724, 107.65]
 
     run_all_values(variables, expression, test_name, equation,
                     test_inputs, expected_results)
@@ -98,7 +98,7 @@ def run_all_values(variables : list, expression, test_name, original_equation, t
     for input, expected in inputs_and_expected:
         input_args = {variables[i] : input[i] for i in range(number_of_variables)}
         output_value = expression.evaluate(**input_args)
-        assert math.isclose(output_value, expected)
+        assert math.isclose(output_value, expected), "Expected: " + str(expected) + ", Output: " + str(output_value)
 
 if __name__ == "__main__":
     test_constant_equation()

--- a/tests/parsers/test_EquationParser.py
+++ b/tests/parsers/test_EquationParser.py
@@ -11,7 +11,7 @@ def test_constant_equation():
                    [1.2]]
     expected_results = [11.2, 11.2, 11.2]
 
-    test_all_values(variables, expression, test_name, equation,
+    run_all_values(variables, expression, test_name, equation,
                     test_inputs, expected_results)
 
 def test_spatial_equation():
@@ -25,7 +25,7 @@ def test_spatial_equation():
                    (1.2, 2.0, 0.2)]
     expected_results = [24.7, 28.62, 19.88]
 
-    test_all_values(variables, expression, test_name, equation,
+    run_all_values(variables, expression, test_name, equation,
                     test_inputs, expected_results)
 
 def test_time_dependent_equation():
@@ -39,7 +39,7 @@ def test_time_dependent_equation():
                    [30.42]]
     expected_results = [100, 200, 304.2]
 
-    test_all_values(variables, expression, test_name, equation,
+    run_all_values(variables, expression, test_name, equation,
                     test_inputs, expected_results)
 
 def test_spatial_and_time_equation():
@@ -53,7 +53,7 @@ def test_spatial_and_time_equation():
                    (1.2, 2.0, 0.2, 0.8)]
     expected_results = [24.7, 5.724, 24.85]
 
-    test_all_values(variables, expression, test_name, equation,
+    run_all_values(variables, expression, test_name, equation,
                     test_inputs, expected_results)
 
 def test_coupled_variables():
@@ -67,7 +67,7 @@ def test_coupled_variables():
                    (1.2, 2.0, 0.2, 0.8)]
     expected_results = [210.6, 5145, 61.5072]
 
-    test_all_values(variables, expression, test_name, equation,
+    run_all_values(variables, expression, test_name, equation,
                     test_inputs, expected_results)
 
 def test_unit_conversion():
@@ -85,10 +85,10 @@ def test_unit_conversion():
                    [4.6]]
     expected_results = [45.94, 68.98, 66.676]
 
-    test_all_values(variables, expression, test_name, equation,
+    run_all_values(variables, expression, test_name, equation,
                     test_inputs, expected_results)
 
-def test_all_values(variables, expression, test_name, original_equation, test_inputs, expected_values):
+def run_all_values(variables : list, expression, test_name, original_equation, test_inputs, expected_values):
     number_of_variables = len(variables)
     number_of_tests = len(test_inputs)
 

--- a/tests/parsers/test_EquationParser.py
+++ b/tests/parsers/test_EquationParser.py
@@ -1,3 +1,5 @@
+import math
+
 from flowforge.parsers.EquationParser import EquationParser
 
 def test_constant_equation():
@@ -96,23 +98,7 @@ def run_all_values(variables : list, expression, test_name, original_equation, t
     for input, expected in inputs_and_expected:
         input_args = {variables[i] : input[i] for i in range(number_of_variables)}
         output_value = expression.evaluate(**input_args)
-        compare_results(test_name, original_equation, input,
-                        output_value, expected)
-
-def compare_results(test_name, equation, input_values, output_value, expected_value):
-    if withinRoundingPrecision(expected_value, output_value):
-        return True
-    else:
-        raise Exception("ERROR in test " + test_name + " : " + \
-                         "Expected " + str(equation) + " @ " + str(input_values) + \
-                         "to give '"+str(expected_value)+"'. Got '"+str(output_value)+"' instead.")
-
-def withinRoundingPrecision(true, predicted):
-    PRECISION_FACTOR = 1e-10
-    if (true - predicted) < PRECISION_FACTOR:
-        return True
-    else:
-        return False
+        assert math.isclose(output_value, expected)
 
 if __name__ == "__main__":
     test_constant_equation()

--- a/tests/parsers/test_EquationParser.py
+++ b/tests/parsers/test_EquationParser.py
@@ -1,0 +1,89 @@
+from flowforge.parsers.EquationParser import EquationParser
+
+def test_spatial_equation():
+    test_name = "test_spatial_equation"
+    equation = '10.1*x + (15.6 / y) - z**2'
+    expression = EquationParser(equation)
+    variables = ['x', 'y', 'z']
+
+    test_inputs = [(1, 1, 1),
+                   (5, 5, 5),
+                   (1.2, 2.0, 0.2)]
+    expected_results = [24.7, 28.62, 19.88]
+
+    test_all_values(variables, expression, test_name, equation,
+                    test_inputs, expected_results)
+
+def test_time_dependent_equation():
+    test_name = "test_time_dependent_equation"
+    equation = '10*t'
+    expression = EquationParser(equation)
+    variables = ['t']
+
+    test_inputs = [[10],
+                   [20],
+                   [30.42]]
+    expected_results = [100, 200, 304.2]
+
+    test_all_values(variables, expression, test_name, equation,
+                    test_inputs, expected_results)
+
+def test_spatial_and_time_equation():
+    test_name = "test_spatial_and_time_equation"
+    equation = '(10.1*x + (15.6 / y) - z**2) / t'
+    expression = EquationParser(equation)
+    variables = ['x', 'z', 'y', 't']
+
+    test_inputs = [(1, 1, 1, 1),
+                   (5, 5, 5, 5),
+                   (1.2, 2.0, 0.2, 0.8)]
+    expected_results = [24.7, 5.724, 24.85]
+
+    test_all_values(variables, expression, test_name, equation,
+                    test_inputs, expected_results)
+
+def test_coupled_variables():
+    test_name = "test_coupled_variables"
+    equation = '(11.9*x + 3.6*z) * 13.2*temperature + 6*pressure'
+    expression = EquationParser(equation, 'temperature', 'pressure')
+    variables = ['x', 'z', 'temperature', 'pressure']
+
+    test_inputs = [(1, 1, 1, 1),
+                   (5, 5, 5, 5),
+                   (1.2, 2.0, 0.2, 0.8)]
+    expected_results = [210.6, 5145, 61.5072]
+
+    test_all_values(variables, expression, test_name, equation,
+                    test_inputs, expected_results)
+
+def test_all_values(variables, expression, test_name, original_equation, test_inputs, expected_values):
+    number_of_variables = len(variables)
+    number_of_tests = len(test_inputs)
+
+    inputs_and_expected = [(test_inputs[i], expected_values[i]) for i in range(number_of_tests)]
+    for input, expected in inputs_and_expected:
+        input_args = {variables[i] : input[i] for i in range(number_of_variables)}
+        output_value = expression.evaluate(**input_args)
+        compare_results(test_name, original_equation, input,
+                        output_value, expected)
+
+def compare_results(test_name, equation, input_values, output_value, expected_value):
+    if withinRoundingPrecision(expected_value, output_value):
+        return True
+    else:
+        raise Exception("ERROR in test " + test_name + " : " + \
+                         "Expected " + str(equation) + " @ " + str(input_values) + \
+                         "to give '"+str(expected_value)+"'. Got '"+str(output_value)+"' instead.")
+
+def withinRoundingPrecision(true, predicted):
+    PRECISION_FACTOR = 1e-10
+    if (true - predicted) < PRECISION_FACTOR:
+        return True
+    else:
+        return False
+
+if __name__ == "__main__":
+    test_spatial_equation()
+    test_time_dependent_equation()
+    test_spatial_and_time_equation()
+    test_coupled_variables()


### PR DESCRIPTION
This PR is in regards to the addition of time-dependent boundary conditions. 

To add this functionality, and `EquationParser` object was added to FlowForge, which takes in a string-equation and generates an evaluable expression via SymPy. The expression should be in the form:
```
value: 'a*x + y/b + (z**2 - c/t)'
```
where `(x, y, z)` are spatial coordinates and `t` the time. The `EquationParser` may also take in coupled variables (temperature, pressure, etc.), though some additions will need to be made down-stream to handle this properly. For now, the spatial and time-dependence aspects work well.

On the flowforge side, in the boundary conditions, all input values for a BC are made into an equation parser object, which has the functionality to handle constant equations (`f(x) = a`). 

See issue #56 for more details.