### PR TITLE
Hexcore hotfix

### DIFF
--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -1668,7 +1668,7 @@ class HexCore(Core):
     def __init__(self,
         pitch: float,
         components: Dict,
-        channel_map: List[List[int]],
+        channel_map: List[List[str]],
         lower_plenum: Dict[str, Dict[str, float]],
         upper_plenum: Dict[str, Dict[str, float]],
         annulus: Dict[str, Dict[str, float]] = None,

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -1677,6 +1677,8 @@ class HexCore(Core):
     ) -> None:
 
         assert pitch >= 0, f"pitch: {pitch} must be positive"
+        self._validate_hex_map(channel_map)
+
         self._pitch = pitch
 
         super().__init__(components, channel_map, lower_plenum, upper_plenum, annulus, orificing, **kwargs)
@@ -1732,6 +1734,25 @@ class HexCore(Core):
                     #      Large differences ripple downstream, and while not pressing, should be noted and
                     #      eventually changed.
         return y_coordinate, x_coordinate
+
+    @staticmethod
+    def _validate_hex_map(channel_map: List[List[str]]) -> None:
+        """Validate that a channel map conforms to hexagonal geometry requirements.
+         This method verifies that the provided channel map is valid for a hexagonal core:
+         - It must not be empty
+
+         Parameters
+         ----------
+         channel_map : List[List[str]]
+             The hexagonal map configuration to validate
+         Raises
+         ------
+         AssertionError
+             If the channel map does not conform to hexagonal geometry requirements
+         """
+
+        num_rows = len(channel_map)
+        assert num_rows > 0, "channel_map: must not be empty"
 
     def _convertUnits(self, uc: UnitConverter) -> None:
         """Convert hexagonal core dimensions to the target unit system.

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -1558,10 +1558,7 @@ class Core(abc.ABC, ParallelComponents):
             for column, value in enumerate(col):
                 if value is not None:
                     centroid_name = f"{str(value):s}-{row+ 1:d}-{column +1:d}"
-                    # BUG: x and y centroids were flipped on creation, which has rotated all cores by 90 degrees.
-                    #      Large differences ripple downstream, and while not pressing, should be noted and
-                    #      eventually changed.
-                    y_centroid, x_centroid = self._getChannelCoords(row, column)
+                    x_centroid, y_centroid = self._getChannelCoords(row, column)
                     centroids[centroid_name] = [x_centroid, y_centroid]
         return centroids
 
@@ -1702,7 +1699,10 @@ class HexCore(Core):
         # Calculate x-coordinate
         x_coordinate = horizontal_spacing * (column - column_center_index) + x_offset
 
-        return x_coordinate, y_coordinate
+        # BUG: x and y centroids were flipped on creation, which has rotated all cores by 90 degrees.
+                    #      Large differences ripple downstream, and while not pressing, should be noted and
+                    #      eventually changed.
+        return y_coordinate, x_coordinate
 
     def _convertUnits(self, uc: UnitConverter) -> None:
         """Convert hexagonal core dimensions to the target unit system.

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -1636,6 +1636,33 @@ class Core(abc.ABC, ParallelComponents):
         """Abstract base method for Core channel coordinates"""
 
 class HexCore(Core):
+    """A hexagonal geometry reactor core component.
+     HexCore implements a reactor core with components arranged in a hexagonal pattern,
+     where each component is positioned based on a hexagonal grid. The arrangement
+     follows a symmetric pattern with a specified pitch (distance between adjacent components).
+     Parameters
+     ----------
+     pitch : float
+         Distance between each of the fuel channels (serial components)
+     components : Dict
+         The collection parallel components which comprise this component.  The structure of
+         this dictionary follows the same convention as :func:`Component.factory`
+     channel_map : List[List[str]]
+         List containing the serial components in the corresponding rings of concentric hexagons
+     lower_plenum : Dict[str, Dict[str,float]]
+         The component specifications for the lower plenum
+         (key: component type, value: component parameters dictionary)
+     upper_plenum : Dict[str, Dict[str,float]]
+         The component specifications for the upper plenum
+         (key: component type, value: component parameters dictionary)
+     annulus : Dict[str, Dict[str,float]], optional
+         The component specifications for the annulus
+         (key: component type, value: component parameters dictionary)
+     orificing : List[List[float]], optional
+         List containing the kloss values associated with serial components in the corresponding rows and
+         columns or concentric rings of the core map - should have the same shape as core map
+     """
+
     def __init__(self,
         pitch: float,
         components: Dict,

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -1641,6 +1641,7 @@ class HexCore(Core):
      HexCore implements a reactor core with components arranged in a hexagonal pattern,
      where each component is positioned based on a hexagonal grid. The arrangement
      follows a symmetric pattern with a specified pitch (distance between adjacent components).
+
      Parameters
      ----------
      pitch : float

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -1637,6 +1637,7 @@ class Core(abc.ABC, ParallelComponents):
 
 class HexCore(Core):
     """A hexagonal geometry reactor core component.
+
      HexCore implements a reactor core with components arranged in a hexagonal pattern,
      where each component is positioned based on a hexagonal grid. The arrangement
      follows a symmetric pattern with a specified pitch (distance between adjacent components).

--- a/tests/input/test_CoreComponents.py
+++ b/tests/input/test_CoreComponents.py
@@ -32,74 +32,6 @@ def create_basic_components():
 # HexCore Tests
 # --------------------------------------------------------------------------------
 
-
-def test_hexcore_validation_odd_rows():
-    """Test hexagonal map validation with odd number of rows"""
-    components, lplen, uplen, annulus = create_basic_components()
-
-    # Valid odd row count
-    valid_map = [[1, 1], [2, 1, 2], [1, 1]]
-    orificing = [[0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0]]
-
-    # This should be valid
-    hc = HexCore(
-        pitch=3,
-        components=components,
-        channel_map=valid_map,
-        lower_plenum=lplen,
-        upper_plenum=uplen,
-        annulus=annulus,
-        orificing=orificing,
-        non_channels=["0"],
-    )
-    assert hc._map == valid_map
-
-
-def test_hexcore_validation_even_rows():
-    """Test hexagonal map validation with even number of rows (should fail)"""
-    components, lplen, uplen, annulus = create_basic_components()
-
-    # Invalid even row count
-    invalid_map = [[1, 1], [2, 1, 2], [1, 1], [2, 2]]
-    orificing = [[0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]
-
-    # This should fail validation
-    with pytest.raises(AssertionError):
-        HexCore(
-            pitch=3,
-            components=components,
-            channel_map=invalid_map,
-            lower_plenum=lplen,
-            upper_plenum=uplen,
-            annulus=annulus,
-            orificing=orificing,
-            non_channels=["0"],
-        )
-
-
-def test_hexcore_validation_row_length():
-    """Test hexagonal map validation with incorrect row lengths"""
-    components, lplen, uplen, annulus = create_basic_components()
-
-    # Let's test with an invalid hexagonal pattern
-    invalid_map = [[1, 1, 1], [2, 1], [1, 1, 1]]  # Middle row should have more elements, not fewer
-    orificing = [[0.0, 0.0, 0.0], [0.0, 0.0], [0.0, 0.0, 0.0]]
-
-    # Verify that this raises some kind of error - the actual error might be different
-    # depending on the validation implementation
-    with pytest.raises(Exception):
-        HexCore(
-            pitch=3,
-            components=components,
-            channel_map=invalid_map,
-            lower_plenum=lplen,
-            upper_plenum=uplen,
-            annulus=annulus,
-            orificing=orificing,
-            non_channels=["0"],
-        )
-
-
 def test_hexcore_empty_map():
     """Test hexagonal map validation with empty map (should fail)"""
     components, lplen, uplen, annulus = create_basic_components()
@@ -141,63 +73,6 @@ def test_hexcore_negative_pitch():
             orificing=orificing,
             non_channels=["0"],
         )
-
-
-def test_hexcore_fill_map():
-    """Test hexagonal map filling with various channel types"""
-    components, lplen, uplen, annulus = create_basic_components()
-
-    channel_map = [[1, 1], [2, 1, 2], [1, 1]]
-    orificing = [[0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0]]
-    non_channels = ["0", "X"]
-
-    # Create core with custom non-channels
-    hc = HexCore(
-        pitch=3,
-        components=components,
-        channel_map=channel_map,
-        lower_plenum=lplen,
-        upper_plenum=uplen,
-        annulus=annulus,
-        orificing=orificing,
-        non_channels=non_channels,
-    )
-
-    # Use the static method directly for testing
-    filled_map = HexCore._fill_map(channel_map, non_channels)
-
-    # Check that filled map has right structure
-    assert len(filled_map) == 3
-    assert len(filled_map[0]) == 2  # First row has 2 elements
-    assert len(filled_map[1]) == 3  # Middle row has 3 elements
-    assert len(filled_map[2]) == 2  # Last row has 2 elements
-
-
-def test_hexcore_minimal_map():
-    """Test hexagonal core with minimal valid map"""
-    components, lplen, uplen, annulus = create_basic_components()
-
-    # Minimal valid map - single element
-    minimal_map = [[1]]
-    orificing = [[0.0]]
-
-    # This should be valid
-    hc = HexCore(
-        pitch=3,
-        components=components,
-        channel_map=minimal_map,
-        lower_plenum=lplen,
-        upper_plenum=uplen,
-        annulus=annulus,
-        orificing=orificing,
-        non_channels=["0"],
-    )
-
-    # Test coordinate calculation
-    x, y = hc._getChannelCoords(0, 0)
-    assert isinstance(x, float)
-    assert isinstance(y, float)
-    assert x == 0.0  # Should be at origin for 1x1 map
 
 
 def test_hexcore_coordinates():
@@ -259,7 +134,7 @@ def test_hexcore_with_no_annulus():
     assert hc.annulus is None
 
     # Other functions should still work
-    mesh = hc._getVTKMesh((0, 0, 0))
+    mesh = hc.getVTKMesh((0, 0, 0))
     assert isinstance(mesh, VTKMesh)
 
 
@@ -585,7 +460,7 @@ def test_core_getVTKMesh():
     )
 
     # Test VTK mesh generation
-    mesh = hc._getVTKMesh((0, 0, 0))
+    mesh = hc.getVTKMesh((0, 0, 0))
     assert isinstance(mesh, VTKMesh)
 
 
@@ -608,3 +483,28 @@ def test_core_orificing_mismatch():
             orificing=wrong_orificing,
             non_channels=["0"],
         )
+
+if __name__ == "__main__":
+    # HexCore
+    test_hexcore_empty_map()
+    test_hexcore_negative_pitch()
+    test_hexcore_coordinates()
+    test_hexcore_with_no_annulus()
+    test_hexcore_unit_conversion()
+
+    # CartCore
+    test_cartcore_validation()
+    test_cartcore_negative_pitch()
+    test_cartcore_empty_map()
+    test_cartcore_different_pitches()
+    test_cartcore_fill_map("left")
+    test_cartcore_fill_map("right")
+    test_cartcore_fill_map("center")
+    test_cartcore_invalid_alignment()
+    test_cartcore_single_element()
+    test_cartcore_unit_conversion()
+
+    # Core Abstract Class
+    test_core_set_extended_components()
+    test_core_getVTKMesh()
+    test_core_orificing_mismatch()


### PR DESCRIPTION
When updating `HexCore` in PR #70, some downstream effects into syth were not accounted for, so this PR makes some tweaks to pass all the SyTH tests.

`HexCore` was more-or-less reverted back to it's original state, with some modifications in style and allowing for `HexCore` to be a child of `Core` instead of `ParallelComponents`.

Later, we can try and go back to this updated version in a cleaner way, though this is not top priority as future development will be focusing more on Cartesian core design (`CartCore`).

Also of note, there is a general issue in how HexCore creates its mesh, which is documented in issue #72 