### PR TITLE
Hotfix for VTK outputs

### DIFF
--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -1458,8 +1458,6 @@ class ParallelComponents(ComponentCollection):
         mesh = VTKMesh()
         mesh += self._lowerPlenum.getVTKMesh(inlet)
         inlet2 = self._lowerPlenum.getOutlet(inlet)
-        mesh += self._lowerNozzle.getVTKMesh(inlet2)
-        mesh += self._lowerManifold.getVTKMesh(inlet2)
         if self._annulus is not None:
             mesh += self._annulus.getVTKMesh(inlet2)
         for cname, centroid in self._centroids.items():
@@ -1472,8 +1470,6 @@ class ParallelComponents(ComponentCollection):
             )
             mesh += self._myParallelComponents[cname].getVTKMesh(i)
         inlet2 = list(self._myParallelComponents.items())[0][1].getOutlet(inlet2)
-        mesh += self._upperManifold.getVTKMesh(inlet2)
-        mesh += self._upperNozzle.getVTKMesh(inlet2)
         mesh += self._upperPlenum.getVTKMesh(inlet2)
         return mesh
 


### PR DESCRIPTION
When trying to visualize data from the Fluid-Solid coupled solver, I added some lines in the vtk-generation script which made it easier to do for that small experiment, but which ended up making some vtk-comparisons in the syth regression tests fail.

This hotfix just reverts these 4 lines back to their original state, 