### PR TITLE
Updated HTC functionality for individual components

### DIFF
--- a/flowforge/input/System.py
+++ b/flowforge/input/System.py
@@ -477,7 +477,7 @@ class System:
         return self._gasname
 
     @property
-    def htcname(self) -> str:
+    def system_htc(self) -> str:
         return self._htc
 
     @property

--- a/flowforge/input/System.py
+++ b/flowforge/input/System.py
@@ -142,11 +142,13 @@ class System:
         self._solid_connectivity = []
         self._bodyforces = []
         self._wallfunctions = []
+        self._component_htc = {} # For component-level HTC
         self._MMBC = None
         self._EBC = None
         self._VBC = None
         self._fluid = None
         self._gas = None
+        self._htc = None # For system-level HTC
 
         # Initializes objects to be empty
         self._boundaryConditionContainer = BoundaryConditions(**{})
@@ -197,6 +199,7 @@ class System:
         boundary_conditions: Dict = {},
         fluid: str = "FLiBe",
         gas=None,
+        HTC= "DittusBoelter"
     ) -> None:
         """Private method for setting up a loop of components
 
@@ -223,9 +226,12 @@ class System:
         components, loop = make_continuous(components, loop)
         self._fluidname = fluid.lower()
         self._gasname = gas if gas is None else gas.lower()
+        self._htc = HTC
         # Loop over each component in the loop, add those components to the list, define the connections between components
         for i, entry in enumerate(loop):
-            self._components.append(deepcopy(components[entry["component"]]))
+            current_component = deepcopy(components[entry["component"]])
+            self._components.append(current_component)
+            self._component_htc[current_component] = entry.get("HTC", HTC)
             bftemp = []
             wftemp = []
             if "BodyForces" in entry:
@@ -247,7 +253,7 @@ class System:
         self._boundaryConditionContainer = BoundaryConditions(**boundary_conditions)
 
     def _setupSegment(
-        self, components: List[Component], order: List[dict], boundary_conditions: Dict = {}, fluid: str = "FLiBe", gas=None
+        self, components: List[Component], order: List[dict], boundary_conditions: Dict = {}, fluid: str = "FLiBe", gas=None, HTC = "DittusBoelter"
     ) -> None:
         """Private method for setting up a segment
 
@@ -272,9 +278,12 @@ class System:
         components, order = make_continuous(components, order)
         self._fluidname = fluid.lower()
         self._gasname = gas if gas is None else gas.lower()
+        self._htc = HTC
         # Loop over each entry in segment, add the components, and connect the compnents to each other
         for i, entry in enumerate(order):
-            self._components.append(deepcopy(components[entry["component"]]))
+            current_component = deepcopy(components[entry["component"]])
+            self._components.append(current_component)
+            self._component_htc[current_component] = entry.get("HTC", HTC)
             bftemp = []
             wftemp = []
             if "BodyForces" in entry:
@@ -387,6 +396,21 @@ class System:
         sysFile = VTKFile(filename, self.getVTKMesh())
         sysFile.writeFile()
 
+    def getComponentHTC(self, component: Component) -> str:
+        """Method for getting the heat transfer coefficient for a component
+
+        Parameters
+        ----------
+        component : Component
+            The component to get the HTC from
+
+        Returns
+        -------
+        str
+            The heat transfer coefficient for the component
+        """
+        return self._component_htc.get(component, self._htc)
+
     @property
     def nCell(self) -> int:
         ncell = 0
@@ -445,3 +469,11 @@ class System:
     @property
     def gasname(self) -> str:
         return self._gasname
+
+    @property
+    def htcname(self) -> str:
+        return self._htc
+
+    @property
+    def component_htc(self) -> Dict[Component, str]:
+        return self._component_htc

--- a/flowforge/input/System.py
+++ b/flowforge/input/System.py
@@ -253,7 +253,13 @@ class System:
         self._boundaryConditionContainer = BoundaryConditions(**boundary_conditions)
 
     def _setupSegment(
-        self, components: List[Component], order: List[dict], boundary_conditions: Dict = {}, fluid: str = "FLiBe", gas=None, HTC = "DittusBoelter"
+        self,
+        components: List[Component],
+        order: List[dict],
+        boundary_conditions: Dict = {},
+        fluid: str = "FLiBe",
+        gas=None,
+        HTC = "DittusBoelter"
     ) -> None:
         """Private method for setting up a segment
 

--- a/flowforge/input/System.py
+++ b/flowforge/input/System.py
@@ -380,7 +380,7 @@ class System:
             components, loop = make_continuous(components, loop, self._auto_nozzle_length)
         self._fluidname = fluid.lower()
         self._gasname = gas if gas is None else gas.lower()
-        self._htc = HTC
+        self._system_htc = HTC
         # Loop over each component in the loop, add those components to the list, define the connections between components
         for i, entry in enumerate(loop):
             component_i = deepcopy(components[entry["component"]])
@@ -440,7 +440,7 @@ class System:
             components, order = make_continuous(components, order, self._auto_nozzle_length)
         self._fluidname = fluid.lower()
         self._gasname = gas if gas is None else gas.lower()
-        self._htc = HTC
+        self._system_htc = HTC
         # Loop over each entry in segment, add the components, and connect the compnents to each other
         for i, entry in enumerate(order):
             component_i = deepcopy(components[entry["component"]])
@@ -571,7 +571,7 @@ class System:
         str
             The heat transfer coefficient for the component
         """
-        return self._component_htc.get(component, self._htc)
+        return self._component_htc.get(component, self._system_htc)
 
     @property
     def nCell(self) -> int:
@@ -646,7 +646,7 @@ class System:
 
     @property
     def system_htc(self) -> str:
-        return self._htc
+        return self._system_htc
 
     @property
     def component_htc(self) -> Dict[Component, str]:

--- a/flowforge/input/System.py
+++ b/flowforge/input/System.py
@@ -89,7 +89,8 @@ class System:
     - A closed loop (possibly of multiple components) in circulation with no external boundaries
 
     The System class also handles unit conversions, boundary conditions, and provides
-    interfaces for visualization and output parsing from various solvers.
+    interfaces for visualization and output parsing from various solvers. It also supports
+    a system-level HTC correlation with optional per-component HTC overrides.
 
     Parameters
     ----------
@@ -116,7 +117,8 @@ class System:
 
     Attributes
     ----------
-    A collection of System setup options.
+    A collection of System setup options, including system-level HTC and component-level HTC
+    correlation settings.
     """
 
     def __init__(
@@ -152,7 +154,7 @@ class System:
         self._solid_body_forces = []
         self._solid_wall_functions = []
 
-        self._component_htc = {}  # For component-level HTC
+        self._component_htc = {}
         self._MMBC = None
         self._EBC = None
         self._VBC = None
@@ -160,7 +162,7 @@ class System:
         # Material variables
         self._fluid = None
         self._gas = None
-        self._system_htc = None # For system-level HTC
+        self._system_htc = None
 
         # Material names
         self._fluidname = None
@@ -569,7 +571,7 @@ class System:
         Returns
         -------
         str
-            The heat transfer coefficient for the component
+            The component-specific HTC correlation, or the system-level HTC if none is set.
         """
         return self._component_htc.get(component, self._system_htc)
 
@@ -646,8 +648,10 @@ class System:
 
     @property
     def system_htc(self) -> str:
+        """Return the system-level HTC correlation."""
         return self._system_htc
 
     @property
     def component_htc(self) -> Dict[Component, str]:
+        """Return the per-component HTC correlation overrides."""
         return self._component_htc

--- a/flowforge/input/System.py
+++ b/flowforge/input/System.py
@@ -160,7 +160,7 @@ class System:
         # Material variables
         self._fluid = None
         self._gas = None
-        self._htc = None # For system-level HTC
+        self._system_htc = None # For system-level HTC
 
         # Material names
         self._fluidname = None


### PR DESCRIPTION
Implemented support for per-component HTC selection while still having a system-level default HTC when unspecified.

- Now stores a system-level HTC and a component-level HTC (defaults to system-level HTC if left unspecified)
- Added function to resolve effective HTC for a component, and for the system-level HTC