### PR TITLE
Fixed tolerance value for EquationParser

### DIFF
--- a/flowforge/parsers/EquationParser.py
+++ b/flowforge/parsers/EquationParser.py
@@ -211,6 +211,6 @@ class EquationParser:
             min(x_bounds), max(x_bounds),
         )
 
-        assert (error < 1e-8), f"Integration error is >1e-8 (error = {error})"
+        assert (error < 1e-7), f"Integration error is >1e-7 (error = {error})"
 
         return integration_result


### PR DESCRIPTION
In the last PR, I added a `computeIntegral` method to `EquationParser`. This uses `scipy.integrate.tplquad` which has a default tolerance value of `1.5e-8`, but I added an internal check on the output error to make sure we catch anything that could go wrong, but I set the check to be `1e-8`, which is lower than the functions tolerance. Therefore, it will often fail.

I've just increased this tolerance to `1e-7` (as that is an acceptable level of error) which will fix any assertion errors coming from using this method.