### PR TITLE
Heat Exchanger Component

### DIFF
--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -297,9 +297,9 @@ class Component:
                 comp_type = key
                 comps = value
                 if comp_type in component_list:
-                    if comp_type == "simple_hx":
+                    if comp_type == "heat_exchanger":
                         for name, parameters in comps.items():
-                            components[f"hx{hx_counter}_primary"] = TubeHX( **parameters)       #Might need to generalize if more than 1 hx
+                            components[f"hx{hx_counter}_primary"] = TubeHX( **parameters)
                             components[f"hx{hx_counter}_secondary"] = ShellHX( **parameters)
                             hx_counter += 1
                     else:

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -2958,7 +2958,7 @@ class MSRE_HX(Component):
         self._Pout = Pout
         self._hin = hin
         self._n = n
-        self._n_sec = (2*n)+1           #bends over itself, plus one node at curved end
+        self._n_sec = (2*n)-1           #bends over itself, plus one node at curved end
         self._costh = np.cos(np.pi / 180 * theta)
         self._theta = theta * np.pi / 180
         self._alpha = alpha * np.pi / 180
@@ -3109,7 +3109,7 @@ class MSRE_HX_primary(MSRE_HX):
         self._Pout = Pout
         self._hin = hin
         self._n = n
-        self._n_sec = (2*n)+1           #bends over itself, plus one node at curved end
+        self._n_sec = (2*n)-1           #bends over itself, plus one node at curved end
         self._costh = np.cos(np.pi / 180 * theta)
         self._theta = theta * np.pi / 180
         self._alpha = alpha * np.pi / 180
@@ -3261,7 +3261,7 @@ class MSRE_HX_secondary(MSRE_HX):
         self._Pout = Pout
         self._hin = hin
         self._n = n
-        self._n_sec = (2*n)+1           #bends over itself, plus one node at curved end
+        self._n_sec = (2*n)-1           #bends over itself, and one node at curved end
         self._costh = np.cos(np.pi / 180 * theta)
         self._theta = theta * np.pi / 180
         self._alpha = alpha * np.pi / 180

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -302,6 +302,11 @@ class Component:
                             components[f"hx{hx_counter}_primary"] = TubeHX( **parameters)
                             components[f"hx{hx_counter}_secondary"] = ShellHX( **parameters)
                             hx_counter += 1
+                    if comp_type == "msre_heat_exchanger":
+                        for name, parameters in comps.items():
+                            components[f"msre_hx{hx_counter}_primary"] = MSRE_HX_primary( **parameters)
+                            components[f"msre_hx{hx_counter}_secondary"] = MSRE_HX_secondary( **parameters)
+                            hx_counter += 1
                     else:
                         for name, parameters in comps.items():
                             components[name] = component_list[comp_type](**parameters)
@@ -2547,6 +2552,7 @@ class HeatExchanger(Component):
     """
     def __init__(
         self,
+        # configuration: str,
         tag: str,
         L: float,
         R_outer: float,
@@ -2572,6 +2578,7 @@ class HeatExchanger(Component):
         self._hx_type = hx_type
         self._Dh = (2*R_outer)-((2*R_inner))      #annuli
         self._tag = tag
+        # self._configuration = configuration
         self._mdotin = mdot_in
         self._Pout = Pout
         self._hin = hin
@@ -2625,6 +2632,10 @@ class HeatExchanger(Component):
     @property
     def getTag(self) -> str:
         return self._tag
+
+    # @property
+    # def getConfiguration(self) -> str:
+    #     return self._configuration
 
     def getOutlet(self, inlet: Tuple[float, float, float]) -> Tuple[float, float, float]:
         x = inlet[0] + self._L * np.sin(self._theta) * np.cos(self._alpha)
@@ -2869,3 +2880,449 @@ class ShellHX(HeatExchanger):
         self._roughness *= uc.lengthConversion
 
 component_list["shell"] = ShellHX
+
+class MSRE_HX(Component):
+    """A heat exchanger component
+        representing the heat exchanger configuration
+        used in the MSRE by Oak Ridge National Labs,
+
+    Parameters
+    ----------
+    L : float
+        Length of the pipe
+    R_shell : float
+        Radius of shell
+    R_tube : float
+        Radius of smaller tubes
+    n_tubes : int
+        Number of smaller tubes within shell
+    tag : str
+        Name of heat exchanger used to couple with proper secondary loop
+    type : str (depreciated)
+        Type of Heat Exchanger, parallel or counter
+    mdot_in : float
+        Inlet mass flow rate
+    Pout : float
+        Outlet pressure
+    hin : float
+        Inlet enthalpy
+    n : int
+        Number of nodes the primary side of the heat exchanger is divided into
+    theta : float
+        Orientation angle of the pipe in the polar direction
+    alpha : float
+        Orientation angle of the pipe in the azimuthal direction
+    Klossinlet : float
+        K-loss coefficient associated with pressure loss at the inlet of the pipe
+    Klossoutlet : float
+        K-loss coefficient associated with pressure loss at the outlet of the pipe
+    Klossavg : float
+        K-loss coefficient associated with pressure loss across the pipe
+    roughness : float
+        Pipe roughness
+    """
+    def __init__(
+        self,
+        tag: str,
+        L: float,
+        R_shell: float,
+        R_tube: float,
+        n_tubes: int,
+        hx_type: str,
+        mdot_in: float = 1,
+        Pout: float = 101325,
+        hin: float = 64064,
+        n: int = 1,
+        theta: float = 0,
+        alpha: float = 0,
+        Klossinlet: float = 0,
+        Klossoutlet: float = 0,
+        Klossavg: float = 0,
+        roughness: float = 0,
+        resolution: int = _CYL_RESOLUTION,
+        **kwargs
+        ) -> None:
+        super().__init__()
+        self._L = L
+        self._Rshell = R_shell
+        self._Rtube = R_tube
+        self._ntubes = n_tubes
+        self._hx_type = hx_type
+        self._Dh = (4*np.pi*((self._Rshell**2)-self._ntubes*(self._Rtube**2)))/((2*self._Rtube)*np.pi*self._ntubes)
+        self._tag = tag
+        self._mdotin = mdot_in
+        self._Pout = Pout
+        self._hin = hin
+        self._n = n
+        self._n_sec = (2*n)+1           #bends over itself, plus one node at curved end
+        self._costh = np.cos(np.pi / 180 * theta)
+        self._theta = theta * np.pi / 180
+        self._alpha = alpha * np.pi / 180
+        self._klossInlet = Klossinlet
+        self._klossOutlet = Klossoutlet
+        self._klossAvg = Klossavg
+        self._roughness = roughness
+        self._res = resolution
+        self._kwargs = kwargs
+
+    @property
+    def flowArea(self) -> float:        #ignores thickness of tubes... need to fix?
+        return np.pi*((self._Rshell**2)-self._ntubes*(self._Rtube**2))
+
+    @property
+    def length(self) -> float:
+        return self._L
+
+    @property
+    def hydraulicDiameter(self):
+        return self._Dh
+
+    @property
+    def heatedPerimeter(self):
+        return (2*self._Rtube)*np.pi*self._ntubes
+
+    @property
+    def heightChange(self):
+        return self._costh*self._L
+
+    @property
+    def costh(self):
+        return self._costh
+
+    @property
+    def r_shell(self) -> float:
+        return self._Rshell
+
+    @property
+    def r_tube(self) -> float:
+        return self._Rtube
+
+    @property
+    def nCell(self) -> int:
+        return self._n
+
+    @property
+    def getTag(self) -> str:
+        return self._tag
+
+    def getOutlet(self, inlet: Tuple[float, float, float]) -> Tuple[float, float, float]:
+        x = inlet[0] + self._L * np.sin(self._theta) * np.cos(self._alpha)
+        y = inlet[1] + self._L * np.sin(self._theta) * np.sin(self._alpha)
+        z = inlet[2] + self._L * np.cos(self._theta)
+        return (x, y, z)
+
+    def getBoundingBox(
+        self, inlet: Tuple[float, float, float]
+    ) -> Tuple[Tuple[float, float, float], Tuple[float, float, float], float, float, float, float, float]:
+        outlet = self.getOutlet(inlet)
+        return [inlet, outlet, self._Rshell, self._Rshell, self._L, self._theta, self._alpha]
+
+    def getVTKMesh(self, inlet: Tuple[float, float, float]) -> VTKMesh:
+        raise NotImplementedError
+        # return genUniformAnnulus(
+        #     self._L, self._Rinner, self._Router, resolution=self._res, naxial_layers=self._n, **self._kwargs
+        # ).translate(inlet[0], inlet[1], inlet[2], self._theta, self._alpha)
+
+    def _convertUnits(self, uc: UnitConverter) -> None:
+        self._L *= uc.lengthConversion
+        self._Router *= uc.lengthConversion
+        self._Rinner *= uc.lengthConversion
+        self._roughness *= uc.lengthConversion
+
+component_list["msre_heat_exchanger"] = MSRE_HX
+
+class MSRE_HX_primary(MSRE_HX):
+    """A heat exchanger component
+        representing the heat exchanger configuration
+        used in the MSRE by Oak Ridge National Labs,
+        primary side
+
+    Parameters
+    ----------
+    L : float
+        Length of the pipe
+    R_shell : float
+        Radius of shell
+    R_tube : float
+        Radius of smaller tubes
+    n_tubes : int
+        Number of smaller tubes within shell
+    tag : str
+        Name of heat exchanger used to couple with proper secondary loop
+    type : str (depreciated)
+        Type of Heat Exchanger, parallel or counter
+    mdot_in : float
+        Inlet mass flow rate
+    Pout : float
+        Outlet pressure
+    hin : float
+        Inlet enthalpy
+    n : int
+        Number of nodes the primary side of the heat exchanger is divided into
+    theta : float
+        Orientation angle of the pipe in the polar direction
+    alpha : float
+        Orientation angle of the pipe in the azimuthal direction
+    Klossinlet : float
+        K-loss coefficient associated with pressure loss at the inlet of the pipe
+    Klossoutlet : float
+        K-loss coefficient associated with pressure loss at the outlet of the pipe
+    Klossavg : float
+        K-loss coefficient associated with pressure loss across the pipe
+    roughness : float
+        Pipe roughness
+    """
+    def __init__(
+        self,
+        tag: str,
+        L: float,
+        R_shell: float,
+        R_tube: float,
+        n_tubes: int,
+        hx_type: str,
+        mdot_in: float = 1,
+        Pout: float = 101325,
+        hin: float = 64064,
+        n: int = 1,
+        theta: float = 0,
+        alpha: float = 0,
+        Klossinlet: float = 0,
+        Klossoutlet: float = 0,
+        Klossavg: float = 0,
+        roughness: float = 0,
+        resolution: int = _CYL_RESOLUTION,
+        **kwargs
+        ) -> None:
+        super().__init__(L = L, R_shell = R_shell, R_tube = R_tube, n_tubes = n_tubes, tag = tag, hx_type = hx_type)
+        self._L = L
+        self._Rshell = R_shell
+        self._Rtube = R_tube
+        self._ntubes = n_tubes
+        self._hx_type = hx_type
+        self._Dh = (self._Rshell**2 - 2*self._ntubes*self._Rtube**2)/self._Rtube
+        self._tag = tag
+        self._mdotin = mdot_in
+        self._Pout = Pout
+        self._hin = hin
+        self._n = n
+        self._n_sec = (2*n)+1           #bends over itself, plus one node at curved end
+        self._costh = np.cos(np.pi / 180 * theta)
+        self._theta = theta * np.pi / 180
+        self._alpha = alpha * np.pi / 180
+        self._klossInlet = Klossinlet
+        self._klossOutlet = Klossoutlet
+        self._klossAvg = Klossavg
+        self._roughness = roughness
+        self._res = resolution
+        self._kwargs = kwargs
+
+    @property
+    def flowArea(self) -> float:        #ignores thickness of tubes... need to fix?
+        return np.pi*((self._Rshell**2)-2*self._ntubes*(self._Rtube**2))
+
+    @property
+    def length(self) -> float:
+        return self._L
+
+    @property
+    def hydraulicDiameter(self):
+        return self._Dh
+
+    @property
+    def heatedPerimeter(self):          #effective heat transfer area
+        return self._ntubes* (2*self._Rtube)*np.pi
+
+    @property
+    def heightChange(self):
+        return self._costh*self._L
+
+    @property
+    def costh(self):
+        return self._costh
+
+    @property
+    def r_shell(self) -> float:
+        return self._Rshell
+
+    @property
+    def r_tube(self) -> float:
+        return self._Rtube
+
+    @property
+    def nCell(self) -> int:
+        return self._n
+
+    @property
+    def getTag(self) -> str:
+        return self._tag
+
+    def getOutlet(self, inlet: Tuple[float, float, float]) -> Tuple[float, float, float]:
+        x = inlet[0] + self._L * np.sin(self._theta) * np.cos(self._alpha)
+        y = inlet[1] + self._L * np.sin(self._theta) * np.sin(self._alpha)
+        z = inlet[2] + self._L * np.cos(self._theta)
+        return (x, y, z)
+
+    def getBoundingBox(
+        self, inlet: Tuple[float, float, float]
+    ) -> Tuple[Tuple[float, float, float], Tuple[float, float, float], float, float, float, float, float]:
+        outlet = self.getOutlet(inlet)
+        return [inlet, outlet, self._Rshell, self._Rshell, self._L, self._theta, self._alpha]
+
+    def getVTKMesh(self, inlet: Tuple[float, float, float]) -> VTKMesh:
+        raise NotImplementedError
+
+    def _convertUnits(self, uc: UnitConverter) -> None:
+        self._L *= uc.lengthConversion
+        self._Rshell *= uc.lengthConversion
+        self._Rtube *= uc.lengthConversion
+        self._roughness *= uc.lengthConversion
+
+component_list["msre_heat_exchanger_prim"] = MSRE_HX_primary
+
+class MSRE_HX_secondary(MSRE_HX):
+    """A heat exchanger component
+        representing the heat exchanger configuration
+        used in the MSRE by Oak Ridge National Labs,
+        secondary side
+
+    Parameters
+    ----------
+    L : float
+        Length of the pipe
+    R_shell : float
+        Radius of shell
+    R_tube : float
+        Radius of smaller tubes
+    n_tubes : int
+        Number of smaller tubes within shell
+    tag : str
+        Name of heat exchanger used to couple with proper secondary loop
+    type : str (depreciated)
+        Type of Heat Exchanger, parallel or counter
+    mdot_in : float
+        Inlet mass flow rate
+    Pout : float
+        Outlet pressure
+    hin : float
+        Inlet enthalpy
+    n : int
+        Number of nodes the primary side of the heat exchanger is divided into
+    theta : float
+        Orientation angle of the pipe in the polar direction
+    alpha : float
+        Orientation angle of the pipe in the azimuthal direction
+    Klossinlet : float
+        K-loss coefficient associated with pressure loss at the inlet of the pipe
+    Klossoutlet : float
+        K-loss coefficient associated with pressure loss at the outlet of the pipe
+    Klossavg : float
+        K-loss coefficient associated with pressure loss across the pipe
+    roughness : float
+        Pipe roughness
+    """
+    def __init__(
+        self,
+        tag: str,
+        L: float,
+        R_shell: float,
+        R_tube: float,
+        n_tubes: int,
+        hx_type: str,
+        mdot_in: float = 1,
+        Pout: float = 101325,
+        hin: float = 64064,
+        n: int = 1,
+        theta: float = 0,
+        alpha: float = 0,
+        Klossinlet: float = 0,
+        Klossoutlet: float = 0,
+        Klossavg: float = 0,
+        roughness: float = 0,
+        resolution: int = _CYL_RESOLUTION,
+        **kwargs
+        ) -> None:
+        super().__init__(L = L, R_shell = R_shell, R_tube = R_tube, n_tubes = n_tubes, tag = tag, hx_type = hx_type)
+        self._L = L
+        self._Rshell = R_shell
+        self._Rtube = R_tube
+        self._ntubes = n_tubes
+        self._hx_type = hx_type
+        self._Dh = 2*self._Rtube*self._ntubes
+        self._tag = tag
+        self._mdotin = mdot_in
+        self._Pout = Pout
+        self._hin = hin
+        self._n = n
+        self._n_sec = (2*n)+1           #bends over itself, plus one node at curved end
+        self._costh = np.cos(np.pi / 180 * theta)
+        self._theta = theta * np.pi / 180
+        self._alpha = alpha * np.pi / 180
+        self._klossInlet = Klossinlet
+        self._klossOutlet = Klossoutlet
+        self._klossAvg = Klossavg
+        self._roughness = roughness
+        self._res = resolution
+        self._kwargs = kwargs
+
+    @property
+    def flowArea(self) -> float:        #area of sum of tubes
+        return self._ntubes*np.pi*(self._Rtube**2)
+
+    @property
+    def length(self) -> float:      #bends over itself, assume twice as long as prim side for mapping ease
+        return 2*self._L
+
+    @property
+    def hydraulicDiameter(self):    #sum tubes
+        return self._Dh
+
+    @property
+    def heatedPerimeter(self):      #effective heated sfc area
+        return self._ntubes* (2*self._Rtube)*np.pi
+
+    @property
+    def heightChange(self):
+        return self._costh*self._L
+
+    @property
+    def costh(self):
+        return self._costh
+
+    @property
+    def r_shell(self) -> float:
+        return self._Rshell
+
+    @property
+    def r_tube(self) -> float:
+        return self._Rtube
+
+    @property
+    def nCell(self) -> int:
+        return self._n_sec
+
+    @property
+    def getTag(self) -> str:
+        return self._tag
+
+    def getOutlet(self, inlet: Tuple[float, float, float]) -> Tuple[float, float, float]:
+        x = inlet[0] + self._L * np.sin(self._theta) * np.cos(self._alpha)
+        y = inlet[1] + self._L * np.sin(self._theta) * np.sin(self._alpha)
+        z = inlet[2] + self._L * np.cos(self._theta)
+        return (x, y, z)
+
+    def getBoundingBox(
+        self, inlet: Tuple[float, float, float]
+    ) -> Tuple[Tuple[float, float, float], Tuple[float, float, float], float, float, float, float, float]:
+        outlet = self.getOutlet(inlet)
+        return [inlet, outlet, self._Rshell, self._Rshell, self._L, self._theta, self._alpha]
+
+    def getVTKMesh(self, inlet: Tuple[float, float, float]) -> VTKMesh:
+        raise NotImplementedError
+
+    def _convertUnits(self, uc: UnitConverter) -> None:
+        self._L *= uc.lengthConversion
+        self._Rshell *= uc.lengthConversion
+        self._Rtube *= uc.lengthConversion
+        self._roughness *= uc.lengthConversion
+
+component_list["msre_heat_exchanger_sec"] = MSRE_HX_secondary

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -2742,6 +2742,10 @@ class TubeHX(HeatExchanger):
     def hydraulicDiameter(self) -> float:
         return self._Dh
 
+    @property
+    def heatedPerimeter(self):
+        return (2*self._Rinner)*np.pi
+
 component_list["tube"] = TubeHX
 
 class ShellHX(HeatExchanger):
@@ -2833,7 +2837,7 @@ class ShellHX(HeatExchanger):
         return self._Dh
 
     @property
-    def heatedPerimeter(self):              #might need to change? not sure what its doing
+    def heatedPerimeter(self):
         return (2*self._Rinner)*np.pi
 
     @property
@@ -3153,6 +3157,10 @@ class MSRE_HX_primary(MSRE_HX):
         return self._n
 
     @property
+    def nTubes(self) -> int:
+        return self._ntubes
+
+    @property
     def getTag(self) -> str:
         return self._tag
 
@@ -3247,7 +3255,7 @@ class MSRE_HX_secondary(MSRE_HX):
         self._Rtube = R_tube
         self._ntubes = n_tubes
         self._hx_type = hx_type
-        self._Dh = 2*self._Rtube*self._ntubes
+        self._Dh = 2*self._Rtube*np.sqrt(self._ntubes)      #diameter of pipe with same flow area as sum of tube flow areas
         self._tag = tag
         self._mdotin = mdot_in
         self._Pout = Pout
@@ -3295,6 +3303,10 @@ class MSRE_HX_secondary(MSRE_HX):
     @property
     def r_tube(self) -> float:
         return self._Rtube
+
+    @property
+    def nTubes(self) -> int:
+        return self._ntubes
 
     @property
     def nCell(self) -> int:

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -3122,7 +3122,7 @@ class MSRE_HX_primary(MSRE_HX):
 
     @property
     def flowArea(self) -> float:        #ignores thickness of tubes... need to fix?
-        return np.pi*((self._Rshell**2)-2*self._ntubes*(self._Rtube**2))
+        return np.pi*((self._Rshell**2)-self._ntubes*(self._Rtube**2))
 
     @property
     def length(self) -> float:
@@ -3134,7 +3134,7 @@ class MSRE_HX_primary(MSRE_HX):
 
     @property
     def heatedPerimeter(self):          #effective heat transfer area
-        return self._ntubes* (2*self._Rtube)*np.pi
+        return (self._ntubes* (2*self._Rtube)*np.pi)
 
     @property
     def heightChange(self):
@@ -3262,6 +3262,7 @@ class MSRE_HX_secondary(MSRE_HX):
         self._hin = hin
         self._n = n
         self._n_sec = (2*n)-1           #bends over itself, and one node at curved end
+        self._n_conversion = self._n_sec/(2*self._n)        #used to make nodes the same size in each loop
         self._costh = np.cos(np.pi / 180 * theta)
         self._theta = theta * np.pi / 180
         self._alpha = alpha * np.pi / 180
@@ -3278,7 +3279,7 @@ class MSRE_HX_secondary(MSRE_HX):
 
     @property
     def length(self) -> float:      #bends over itself, assume twice as long as prim side for mapping ease
-        return 2*self._L
+        return 2*self._L*self._n_conversion
 
     @property
     def hydraulicDiameter(self):    #sum tubes

--- a/flowforge/input/Components.py
+++ b/flowforge/input/Components.py
@@ -291,13 +291,20 @@ class Component:
             (key: Component name, value: Component object)
         """
         components = {}
+        hx_counter = 1
         for key, value in indict.items():
             if isinstance(value, dict):
                 comp_type = key
                 comps = value
                 if comp_type in component_list:
-                    for name, parameters in comps.items():
-                        components[name] = component_list[comp_type](**parameters)
+                    if comp_type == "simple_hx":
+                        for name, parameters in comps.items():
+                            components[f"hx{hx_counter}_primary"] = TubeHX( **parameters)       #Might need to generalize if more than 1 hx
+                            components[f"hx{hx_counter}_secondary"] = ShellHX( **parameters)
+                            hx_counter += 1
+                    else:
+                        for name, parameters in comps.items():
+                            components[name] = component_list[comp_type](**parameters)
                 else:
                     raise TypeError("Unknown component type: " + comp_type)
             elif isinstance(value, Component):
@@ -2499,3 +2506,366 @@ class Nozzle(SerialComponents):
 
 
 component_list["nozzle"] = Nozzle
+
+class HeatExchanger(Component):
+    """A heat exchanger component
+        representing just the annulus (outer shell)
+        of the component
+
+    Parameters
+    ----------
+    L : float
+        Length of the pipe
+    R : float
+        Outer radius of outside pipe
+    r : float
+        Inner radius of outside pipe
+    tag : str
+        Name of heat exchanger used to couple with proper secondary loop
+    type : str
+        Type of Heat Exchanger, parallel or counter
+    mdot_in : float
+        Inlet mass flow rate
+    Pout : float
+        Outlet pressure
+    hin : float
+        Inlet enthalpy
+    n : int
+        Number of segments the pipe is divided into
+    theta : float
+        Orientation angle of the pipe in the polar direction
+    alpha : float
+        Orientation angle of the pipe in the azimuthal direction
+    Klossinlet : float
+        K-loss coefficient associated with pressure loss at the inlet of the pipe
+    Klossoutlet : float
+        K-loss coefficient associated with pressure loss at the outlet of the pipe
+    Klossavg : float
+        K-loss coefficient associated with pressure loss across the pipe
+    roughness : float
+        Pipe roughness
+    """
+    def __init__(
+        self,
+        tag: str,
+        L: float,
+        R_outer: float,
+        R_inner: float,
+        hx_type: str,
+        mdot_in: float = 1,
+        Pout: float = 101325,
+        hin: float = 64064,
+        n: int = 1,
+        theta: float = 0,
+        alpha: float = 0,
+        Klossinlet: float = 0,
+        Klossoutlet: float = 0,
+        Klossavg: float = 0,
+        roughness: float = 0,
+        resolution: int = _CYL_RESOLUTION,
+        **kwargs
+        ) -> None:
+        super().__init__()
+        self._L = L
+        self._Router = R_outer
+        self._Rinner = R_inner
+        self._hx_type = hx_type
+        self._Dh = (2*R_outer)-((2*R_inner))      #annuli
+        self._tag = tag
+        self._mdotin = mdot_in
+        self._Pout = Pout
+        self._hin = hin
+        self._n = n
+        self._costh = np.cos(np.pi / 180 * theta)
+        self._theta = theta * np.pi / 180
+        self._alpha = alpha * np.pi / 180
+        self._klossInlet = Klossinlet
+        self._klossOutlet = Klossoutlet
+        self._klossAvg = Klossavg
+        self._roughness = roughness
+        self._res = resolution
+        self._kwargs = kwargs
+
+    @property
+    def flowArea(self) -> float:
+        return np.pi*((self._Router**2)-(self._Rinner**2))        #annuli area
+
+    @property
+    def length(self) -> float:
+        return self._L
+
+    @property
+    def hydraulicDiameter(self):
+        return self._Dh
+
+    @property
+    def heatedPerimeter(self):              #might need to change? not sure what its doing
+        return (2*self._Rinner)*np.pi
+
+    @property
+    def heightChange(self):
+        return self._costh*self._L
+
+    @property
+    def costh(self):
+        return self._costh
+
+    @property
+    def r_outer(self) -> float:
+        return self._Router
+
+    @property
+    def r_inner(self) -> float:
+        return self._Rinner
+
+    @property
+    def nCell(self) -> int:
+        return self._n
+
+    @property
+    def getTag(self) -> str:
+        return self._tag
+
+    def getOutlet(self, inlet: Tuple[float, float, float]) -> Tuple[float, float, float]:
+        x = inlet[0] + self._L * np.sin(self._theta) * np.cos(self._alpha)
+        y = inlet[1] + self._L * np.sin(self._theta) * np.sin(self._alpha)
+        z = inlet[2] + self._L * np.cos(self._theta)
+        return (x, y, z)
+
+    def getBoundingBox(
+        self, inlet: Tuple[float, float, float]
+    ) -> Tuple[Tuple[float, float, float], Tuple[float, float, float], float, float, float, float, float]:
+        outlet = self.getOutlet(inlet)
+        return [inlet, outlet, self._Router, self._Router, self._L, self._theta, self._alpha]
+
+    def getVTKMesh(self, inlet: Tuple[float, float, float]) -> VTKMesh:
+        return genUniformAnnulus(
+            self._L, self._Rinner, self._Router, resolution=self._res, naxial_layers=self._n, **self._kwargs
+        ).translate(inlet[0], inlet[1], inlet[2], self._theta, self._alpha)
+
+    def _convertUnits(self, uc: UnitConverter) -> None:
+        self._L *= uc.lengthConversion
+        self._Router *= uc.lengthConversion
+        self._Rinner *= uc.lengthConversion
+        self._roughness *= uc.lengthConversion
+
+component_list["heat_exchanger"] = HeatExchanger
+
+class TubeHX(HeatExchanger):
+    """Heat exchanger component
+        representing just the inner pipe of component
+
+    Parameters
+    ----------
+    L : float
+        Length of the pipe
+    Cross_section_name : string
+        Geometry of the cross section of the pipe. Allowed names are circular, square, rectangular, and stadium.
+    Ac : float
+        Flow area of the pipe
+    Dh : float
+        Hydraulic diameter of the pipe
+    n : int
+        Number of segments the pipe is divided into
+    theta : float
+        Orientation angle of the pipe in the polar direction
+    alpha : float
+        Orientation angle of the pipe in the azimuthal direction
+    Klossinlet : float
+        K-loss coefficient associated with pressure loss at the inlet of the pipe
+    Klossoutlet : float
+        K-loss coefficient associated with pressure loss at the outlet of the pipe
+    Klossavg : float
+        K-loss coefficient associated with pressure loss across the pipe
+    roughness : float
+        Pipe roughness
+    pctHeated: float
+        Fraction of the pipe that is heated. Used for calculating heated perimeter.
+        Defaults to 1 (i.e. the entire pipe is heated)
+    """
+    def __init__(
+        self,
+        tag: str,
+        L: float,
+        R_outer: float,
+        R_inner: float,
+        hx_type: str,
+        mdot_in: float = 1,
+        Pout: float = 101325,
+        hin: float = 64064,
+        cross_section_name="circular",
+        n: int = 1,
+        theta: float = 0,
+        alpha: float = 0,
+        Klossinlet: float = 0,
+        Klossoutlet: float = 0,
+        Klossavg: float = 0,
+        roughness: float = 0,
+        resolution: int = _CYL_RESOLUTION,
+        **kwargs
+        ) -> None:
+        super().__init__(L = L, R_inner = R_inner, R_outer = R_outer, tag = tag, hx_type = hx_type)
+        self._L = L
+        self._Router = R_outer
+        self._Rinner = R_inner
+        self._Dh = (2*R_inner)
+        self._mdotin = mdot_in
+        self._Pout = Pout
+        self._hin = hin
+        self._n = n
+        self._costh = np.cos(np.pi / 180 * theta)
+        self._theta = theta * np.pi / 180
+        self._alpha = alpha * np.pi / 180
+        self._klossInlet = Klossinlet
+        self._klossOutlet = Klossoutlet
+        self._klossAvg = Klossavg
+        self._roughness = roughness
+        self._res = resolution
+        self._kwargs = kwargs
+
+    @property
+    def flowArea(self):
+        return np.pi*(self._Rinner**2)
+
+    @property
+    def hydraulicDiameter(self) -> float:
+        return self._Dh
+
+component_list["tube"] = TubeHX
+
+class ShellHX(HeatExchanger):
+    """Heat exchanger component
+        representing just the outer shell of component
+
+    Parameters
+    ----------
+    L : float
+        Length of the pipe
+    Cross_section_name : string
+        Geometry of the cross section of the pipe. Allowed names are circular, square, rectangular, and stadium.
+    Ac : float
+        Flow area of the pipe
+    Dh : float
+        Hydraulic diameter of the pipe
+    n : int
+        Number of segments the pipe is divided into
+    theta : float
+        Orientation angle of the pipe in the polar direction
+    alpha : float
+        Orientation angle of the pipe in the azimuthal direction
+    Klossinlet : float
+        K-loss coefficient associated with pressure loss at the inlet of the pipe
+    Klossoutlet : float
+        K-loss coefficient associated with pressure loss at the outlet of the pipe
+    Klossavg : float
+        K-loss coefficient associated with pressure loss across the pipe
+    roughness : float
+        Pipe roughness
+    pctHeated: float
+        Fraction of the pipe that is heated. Used for calculating heated perimeter.
+        Defaults to 1 (i.e. the entire pipe is heated)
+    """
+    def __init__(
+        self,
+        tag: str,
+        L: float,
+        R_outer: float,
+        R_inner: float,
+        hx_type: str,
+        mdot_in: float = 1,
+        Pout: float = 101325,
+        hin: float = 64064,
+        cross_section_name="circular",
+        n: int = 1,
+        theta: float = 0,
+        alpha: float = 0,
+        Klossinlet: float = 0,
+        Klossoutlet: float = 0,
+        Klossavg: float = 0,
+        roughness: float = 0,
+        resolution: int = _CYL_RESOLUTION,
+        **kwargs
+        ) -> None:
+        super().__init__(L = L, R_inner = R_inner, R_outer = R_outer, tag = tag, hx_type = hx_type)
+        self._L = L
+        self._Router = R_outer
+        self._Rinner = R_inner
+        self._Dh = (2*R_outer)-((2*R_inner))      #annuli
+        self._mdotin = mdot_in
+        self._Pout = Pout
+        self._hin = hin
+        self._n = n
+        self._costh = np.cos(np.pi / 180 * theta)
+        self._theta = theta * np.pi / 180
+        self._alpha = alpha * np.pi / 180
+        self._klossInlet = Klossinlet
+        self._klossOutlet = Klossoutlet
+        self._klossAvg = Klossavg
+        self._roughness = roughness
+        self._res = resolution
+        self._kwargs = kwargs
+
+    @property
+    def flowArea(self) -> float:
+        return np.pi*((self._Router**2)-(self._Rinner**2))        #annuli area
+
+    @property
+    def effFlowArea(self) -> float:     #to be used to calculate accurate Reynolds
+        return np.pi*((self._Router**2) - self._ntubes*(self._Rinner**2))
+
+    @property
+    def length(self) -> float:
+        return self._L
+
+    @property
+    def hydraulicDiameter(self):
+        return self._Dh
+
+    @property
+    def heatedPerimeter(self):              #might need to change? not sure what its doing
+        return (2*self._Rinner)*np.pi
+
+    @property
+    def heightChange(self):
+        return self._costh*self._L
+
+    @property
+    def costh(self):
+        return self._costh
+
+    @property
+    def r_outer(self) -> float:
+        return self._Router
+
+    @property
+    def r_inner(self) -> float:
+        return self._Rinner
+
+    @property
+    def nCell(self) -> int:
+        return self._n
+
+    def getOutlet(self, inlet: Tuple[float, float, float]) -> Tuple[float, float, float]:
+        x = inlet[0] + self._L * np.sin(self._theta) * np.cos(self._alpha)
+        y = inlet[1] + self._L * np.sin(self._theta) * np.sin(self._alpha)
+        z = inlet[2] + self._L * np.cos(self._theta)
+        return (x, y, z)
+
+    def getBoundingBox(
+        self, inlet: Tuple[float, float, float]
+    ) -> Tuple[Tuple[float, float, float], Tuple[float, float, float], float, float, float, float, float]:
+        outlet = self.getOutlet(inlet)
+        return [inlet, outlet, self._Router, self._Router, self._L, self._theta, self._alpha]
+
+    def getVTKMesh(self, inlet: Tuple[float, float, float]) -> VTKMesh:
+        return genUniformAnnulus(
+            self._L, self._Rinner, self._Router, resolution=self._res, naxial_layers=self._n, **self._kwargs
+        ).translate(inlet[0], inlet[1], inlet[2], self._theta, self._alpha)
+
+    def _convertUnits(self, uc: UnitConverter) -> None:
+        self._L *= uc.lengthConversion
+        self._Router *= uc.lengthConversion
+        self._Rinner *= uc.lengthConversion
+        self._roughness *= uc.lengthConversion
+
+component_list["shell"] = ShellHX

--- a/flowforge/materials/Fluid.py
+++ b/flowforge/materials/Fluid.py
@@ -603,3 +603,109 @@ class CharlieCustom(FLiBe_UF4):
         Returns 1.1
         """
         return 1.1 + h * 0
+
+
+class Constant_FLiBe_UF4(Fluid):
+    """
+    Fluid subclass with FLiBe_UF4 molten salt properties.
+
+    This class implements the specific properties of FLiBe_UF4 molten salt
+    with a composition of 67-33 mol% (2LiF-BeF_2).
+
+    Parameters
+    ----------
+    name : str
+        Name of the fluid material
+
+    Attributes
+    ----------
+    name : str
+        Name of the fluid material
+
+    Notes
+    -----
+    Molar Percent: 67-33 mol% (2LiF-BeF_2)
+
+    Caveats:
+    In this section a list of temperature dependent caveats are presented
+    with any listed uncertainties from the literature [1,2,3]
+
+    References
+    ----------
+    [1] C. Davis, "Implementation of Molten Salt Properties into RELAP5-3D/ATHENA," U.S. Department of Energy,
+        Tech. Rep., Jan. 2005. doi: 10.2172/910991. Available: https://www.osti.gov/biblio/910991.
+
+    [2] R. Romatoski and L.-W. Hu, "Fluoride salt coolant properties for nuclear reactor applications:
+        A review," *Annals of Nuclear Energy*, vol. 109, pp. 635-647, Nov. 2017. doi: 10.1016/j.anucene.2017.05.036.
+
+    [3] M. S. Sohal, M. A. Ebner, P. Sabharwall, and P. Sharpe, "Engineering Database of Liquid Salt Thermophysical
+        and Thermochemical Properties," Idaho National Laboratory, Tech. Rep. INL/EXT-10-18297, Rev. 1, June 2013.
+        Available: https://inldigitallibrary.inl.gov/sites/STI/STI/5698704.pdf.
+    """
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._Tref = 273.15  # temperature where enthalpy is 0
+
+    def conductivity(self, h: float) -> float:
+        """
+        Thermal conductivity [W/m-K]:
+        Validated for temp range 459-610 K and at 873 K with ± 10-50% uncertainty,
+        ref. [1], pg.  10, Table 7.
+        ref. [2], pg. 638, Table 3.
+        """
+        return 1.1 + h * 0
+
+    def density(self, h: float) -> float:
+        """
+        Density [kg/m^3]:
+        Validated for temp range 800-1080 K,
+        ref. [3], pg. 6, eq. (2.13)
+        """
+        density = 2413 - (0.488 * 900) + h*0
+        assert np.all(density >= 0)
+        return density
+
+    def viscosity(self, h: float) -> float:
+        """
+        Dynamic viscosity [kg/m-s]:
+        Validated for temp range 873-1073 K,
+        ref. [3], pg. 7, eq. (2.18)
+        """
+        T = 900
+        return (0.116e-3) * np.exp(3755.0 / T)
+
+    def surface_tension(self, h: float) -> float:
+        """
+        Surface tension [N/m]:
+        Validated for temp range 773.15-1073.15 K with ± 3% uncertainty,
+        under a dry argon, helium or nitrogen gas enviorment,
+        ref. [3], pg. 8 and 33, eq. (2.19)
+        """
+        T = 900
+        return 0.295778 - ((0.12e-3) * T)
+
+    def specific_heat(self, h: float) -> float:
+        """
+        Specific heat capacity [J/kg-K] (Isobaric):
+        Validated for temp range 788-1093 K with ± 3% uncertainty,
+        ref. [1], pg.   3, Table 1.
+        ref. [2], pg. 637, Table 2.
+        """
+        return 2386 + h * 0
+
+    def temperature(self, h: float) -> float:
+        """
+        Temperature [K]
+        """
+        temp = h / self.specific_heat(h) + self._Tref  # only true because specific heat is constant
+        # print(f"temp: {temp}")
+        # print(f"from h = {h}")
+        # assert np.all(temp >= 0)
+        return temp
+
+    def enthalpy(self, T: float) -> float:
+        """
+        Specific enthalpy [J/kg]
+        """
+        return self.specific_heat(0) * (T - self._Tref)  # only true because specific heat is constant

--- a/flowforge/materials/Fluid.py
+++ b/flowforge/materials/Fluid.py
@@ -699,9 +699,7 @@ class Constant_FLiBe_UF4(Fluid):
         Temperature [K]
         """
         temp = h / self.specific_heat(h) + self._Tref  # only true because specific heat is constant
-        # print(f"temp: {temp}")
-        # print(f"from h = {h}")
-        # assert np.all(temp >= 0)
+        assert np.all(temp >= 0)
         return temp
 
     def enthalpy(self, T: float) -> float:


### PR DESCRIPTION
HeatExchanger component and associated changes to provide a coupling between two loops, using one component. HeatExchanger is parent to ShellHX and TubeHX where shell is the outer tube, and tube is the inner, in the concentric tube heat exchanger configuration. The factory method is modified to then distribute each component to primary and secondary loops as indicated in the input file, while allowing for multiple heat exchangers to be present in the system. 

Constant_FLiBe_UF4 class in Fluid made for testing to be made easier too. 